### PR TITLE
Change Pulse value documentation to be aligned with the experimental result.

### DIFF
--- a/Notes/RedLED.md
+++ b/Notes/RedLED.md
@@ -8,7 +8,7 @@ Prescaler: $0 - 2^{16}$ (Unitless value to scale the system timer clock)
 
 Counter Period
 
-Pulse: > pulse, output on; < pulse, output off.
+Pulse: < pulse, output on; > pulse, output off.
 
 $T$: Period
 


### PR DESCRIPTION
The Pulse value documentation was wrong before.
The LED will be turned on when the counter value is smaller than the Pulse value.
The LED will be turned off when the counter value is larger than the Pulse value.
This means a lower Pulse value will let the LED have less time to be turned on, resulting a dimmer light visually.